### PR TITLE
Disable the compression middleware

### DIFF
--- a/biothings_annotator/application/middleware/__init__.py
+++ b/biothings_annotator/application/middleware/__init__.py
@@ -15,6 +15,12 @@ def build_middleware() -> list[dict]:
         priority: Union[Default, int] = _default,
     ) -> Union[MiddlewareType, Middleware]:
     """
-    compression_middleware = {"middleware": compress_response, "attach_to": "response"}
-    middleware_collection = [compression_middleware]
+
+    # Temporarily removing the middleware compression due to 502 gateway errors
+    # Date: August 28th 2024
+
+    # compression_middleware = {"middleware": compress_response, "attach_to": "response"}
+    # middleware_collection = [compression_middleware]
+
+    middleware_collection = []
     return middleware_collection


### PR DESCRIPTION
Temporary measure to see if the main reason we're seeing this 500 HTTP errors is our compression