### PR TITLE
Make optional extra enrichment best-effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ python3 -m biothings_annotator --host "172.84.29.248" --port 9384 --workers 12 -
 
 The annotator query backend is controlled with `ANNOTATOR_QUERY_BACKEND`. Supported values are
 `biothings` and `elasticsearch`; when unset, the service uses `biothings`.
+The Helm/Jenkins deployment defaults set `ANNOTATOR_QUERY_BACKEND=elasticsearch`; set it to
+`biothings` during deployment to switch back.
 
 
 ### Builds

--- a/biothings_annotator/annotator/annotator.py
+++ b/biothings_annotator/annotator/annotator.py
@@ -92,13 +92,21 @@ class Annotator:
         res_by_id is the output of query_annotations, node_type is the same passed to query_annotations
         """
         logger.info("Transforming output annotations for %s %ss...", len(res_by_id), node_type)
-        atc_client = get_query_client(
-            node_type="extra",
-            query_backend=self.query_backend,
-            api_host=self.api_host,
-            elasticsearch_connection=self.elasticsearch_connection,
-        )
-        atc_cache = await load_atc_cache(self.api_host, atc_client=atc_client, cache_key=self.atc_cache_key)
+        atc_cache = {}
+        if node_type == "chem":
+            try:
+                atc_client = get_query_client(
+                    node_type="extra",
+                    query_backend=self.query_backend,
+                    api_host=self.api_host,
+                    elasticsearch_connection=self.elasticsearch_connection,
+                )
+                if atc_client is None or not hasattr(atc_client, "query"):
+                    logger.warning("Failed to get the extra annotation query client. ATC enrichment is skipped.")
+                else:
+                    atc_cache = await load_atc_cache(self.api_host, atc_client=atc_client, cache_key=self.atc_cache_key)
+            except Exception as exc:
+                logger.warning("Unable to load WHO ATC code-to-name mapping. ATC enrichment is skipped: %r", exc)
         transformer = ResponseTransformer(res_by_id, node_type, self.api_host, atc_cache)
         transformer.transform()
         logger.info("Done.")
@@ -110,21 +118,33 @@ class Annotator:
         """
         Append extra annotations to the existing node_d
         """
-        node_id_list = node_d.keys() if node_id_subset is None else node_id_subset
+        node_id_list = list(node_d.keys() if node_id_subset is None else node_id_subset)
+        if not node_id_list:
+            logger.info("No extra annotations requested.")
+            return
+
         cnt = 0
         logger.info("Retrieving extra annotations...")
-        extra_api = get_query_client(
-            node_type="extra",
-            query_backend=self.query_backend,
-            api_host=self.api_host,
-            elasticsearch_connection=self.elasticsearch_connection,
-        )
+        try:
+            extra_api = get_query_client(
+                node_type="extra",
+                query_backend=self.query_backend,
+                api_host=self.api_host,
+                elasticsearch_connection=self.elasticsearch_connection,
+            )
+        except Exception as exc:
+            logger.warning("Unable to get the extra annotation query client. Extra annotations are skipped: %r", exc)
+            return
         if extra_api is None or not hasattr(extra_api, "querymany"):
-            logger.error("Failed to get the extra annotation query client. Extra annotations are skipped.")
+            logger.warning("Failed to get the extra annotation query client. Extra annotations are skipped.")
             return
 
         for node_id_batch in batched(node_id_list, batch_n):
-            extra_res = await extra_api.querymany(node_id_batch, scopes="_id", fields="all")
+            try:
+                extra_res = await extra_api.querymany(node_id_batch, scopes="_id", fields="all")
+            except Exception as exc:
+                logger.warning("Unable to retrieve extra annotations. Extra annotations are skipped: %r", exc)
+                return
             for hit in extra_res:
                 if hit.get("notfound", False):
                     continue
@@ -161,7 +181,7 @@ class Annotator:
         if not raw:
             res = await self.transform(res, node_type)
 
-        if res and include_extra:
+        if res and include_extra and node_type == "chem":
             await self.append_extra_annotations(res)
 
         curie_annotation = {curie: res.get(_id, {})}
@@ -278,7 +298,7 @@ class Annotator:
 
         if include_extra:
             # currently, we only need to append extra annotations for chem nodes
-            await self.append_extra_annotations(_node_d, node_id_subset=node_list_by_type["chem"])
+            await self.append_extra_annotations(_node_d, node_id_subset=node_list_by_type.get("chem", []))
 
         # place the annotation objects back to the original node_d as TRAPI attributes
         for node_id, res in _node_d.items():

--- a/biothings_annotator/annotator/transformer.py
+++ b/biothings_annotator/annotator/transformer.py
@@ -31,9 +31,10 @@ async def load_atc_cache(api_host: str, atc_client: Optional[object] = None, cac
         logger.info("Loading WHO ATC code-to-name mapping...")
         atc_client = atc_client or get_client("extra", api_host)
         atc_li = await atc_client.query("_exists_:atc.code", fields="atc.code,atc.name", fetch_all=True)
-        atc_cache[cache_key] = {}
+        cache = {}
         async for atc in atc_li:
-            atc_cache[cache_key][atc["atc"]["code"]] = atc["atc"]["name"]
+            cache[atc["atc"]["code"]] = atc["atc"]["name"]
+        atc_cache[cache_key] = cache
         logger.info(f"Loaded {len(atc_cache[cache_key])} WHO ATC code-to-name mappings.")
     return atc_cache[cache_key]
 

--- a/biothings_annotator/annotator/utils.py
+++ b/biothings_annotator/annotator/utils.py
@@ -96,16 +96,16 @@ def get_client(node_type: str, api_host: str) -> Union[biothings_client.AsyncBio
     elif client_configuration is not None and isinstance(client_configuration, dict):
         try:
             client = biothings_client.get_async_client(**client_configuration)
-        except Exception as exc:
-            logger.error("%s [%s]", exc, client_configuration)
+        except Exception:
+            logger.exception("Unable to create annotator client [%s]", client_configuration)
             client = None
 
     elif client_endpoint is not None and isinstance(client_endpoint, str):
         client_url = f"{api_host}/{client_endpoint}"
         try:
             client = biothings_client.get_async_client(biothing_type=None, instance=True, url=client_url)
-        except Exception as exc:
-            logger.error("%s [%s]", exc, client_url)
+        except Exception:
+            logger.exception("Unable to create endpoint-backed annotator client [%s]", client_url)
             client = None
 
     else:

--- a/biothings_annotator/annotator/utils.py
+++ b/biothings_annotator/annotator/utils.py
@@ -96,16 +96,16 @@ def get_client(node_type: str, api_host: str) -> Union[biothings_client.AsyncBio
     elif client_configuration is not None and isinstance(client_configuration, dict):
         try:
             client = biothings_client.get_async_client(**client_configuration)
-        except RuntimeError as runtime_error:
-            logger.error("%s [%s]", runtime_error, client_configuration)
+        except Exception as exc:
+            logger.error("%s [%s]", exc, client_configuration)
             client = None
 
     elif client_endpoint is not None and isinstance(client_endpoint, str):
         client_url = f"{api_host}/{client_endpoint}"
         try:
             client = biothings_client.get_async_client(biothing_type=None, instance=True, url=client_url)
-        except RuntimeError as runtime_error:
-            logger.error("%s [%s]", runtime_error, client_url)
+        except Exception as exc:
+            logger.error("%s [%s]", exc, client_url)
             client = None
 
     else:

--- a/biothings_annotator/application/views/status.py
+++ b/biothings_annotator/application/views/status.py
@@ -18,7 +18,7 @@ class StatusView(HTTPMethodView):
 
         annotator = Annotator()
         try:
-            annotated_node = await annotator.annotate_curie(curie, fields=fields, raw=False, include_extra=False)
+            annotated_node = await annotator.annotate_curie(curie, fields=fields, raw=True, include_extra=False)
 
             if "NCBIGene:1017" not in annotated_node:
                 return sanic.json(None, status=500)
@@ -40,7 +40,7 @@ class StatusView(HTTPMethodView):
 
         annotator = Annotator()
         try:
-            annotated_node = await annotator.annotate_curie(curie, fields=fields, raw=False, include_extra=False)
+            annotated_node = await annotator.annotate_curie(curie, fields=fields, raw=True, include_extra=False)
 
             if "NCBIGene:1017" not in annotated_node:
                 result = {"success": False, "error": "Service unavailable due to a failed data check!"}

--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     parameters {
         string(name: 'BUILD_VERSION', defaultValue: '', description: 'The build version to deploy (optional)')
         string(name: 'AWS_REGION', defaultValue: 'us-east-1', description: 'AWS Region to deploy')
-        choice(name: 'ANNOTATOR_QUERY_BACKEND', choices: ['biothings', 'elasticsearch'], description: 'Annotator query backend to deploy')
+        choice(name: 'ANNOTATOR_QUERY_BACKEND', choices: ['elasticsearch', 'biothings'], description: 'Annotator query backend to deploy')
     }
     triggers {
         pollSCM('H/5 * * * *')

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,5 +12,5 @@ sed -i.bak \
 rm values.yaml.bak
 
 helm -n ${namespace} upgrade --install ${projectName} \
-    --set containers.query_backend="${ANNOTATOR_QUERY_BACKEND:-biothings}" \
+    --set containers.query_backend="${ANNOTATOR_QUERY_BACKEND:-elasticsearch}" \
     -f values-ncats.yaml ./

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
               value: {{ .Values.containers.es_host }}
             - name: ANNOTATOR_QUERY_BACKEND
               value: {{ .Values.containers.query_backend | quote }}
+            - name: ELASTICSEARCH_CONNECTION
+              value: {{ .Values.containers.elasticsearch_connection | quote }}
             - name: OPENTELEMETRY_ENABLED
               value: "{{ .Values.containers.OPENTELEMETRY_ENABLED_VALUE }}"  
             - name: OPENTELEMETRY_JAEGER_HOST

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -31,8 +31,10 @@ spec:
               value: {{ .Values.containers.es_host }}
             - name: ANNOTATOR_QUERY_BACKEND
               value: {{ .Values.containers.query_backend | quote }}
+            {{- with .Values.containers.elasticsearch_connection }}
             - name: ELASTICSEARCH_CONNECTION
-              value: {{ .Values.containers.elasticsearch_connection | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             - name: OPENTELEMETRY_ENABLED
               value: "{{ .Values.containers.OPENTELEMETRY_ENABLED_VALUE }}"  
             - name: OPENTELEMETRY_JAEGER_HOST

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -22,7 +22,8 @@ image:
 containers:
   name: biothingsannotator
   es_host: ES_HOST_VALUE
-  query_backend: biothings
+  query_backend: elasticsearch
+  elasticsearch_connection: ci_forward
   port: 9000
 
 env:

--- a/tests/test_application_endpoints.py
+++ b/tests/test_application_endpoints.py
@@ -18,23 +18,30 @@ async def test_status_get(test_annotator: sanic.Sanic, endpoint: str):
     """
     Tests the Status endpoint GET when the response is HTTP 200
     """
-    request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
+    with patch.object(
+        Annotator, "annotate_curie", return_value={"NCBIGene:1017": [{"query": "1017", "_id": "1017"}]}
+    ) as mock_annotate_curie:
+        request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
 
-    assert request.method == "GET"
-    assert request.query_string == ""
-    assert request.scheme == "http"
-    assert request.server_path == endpoint
+        mock_annotate_curie.assert_awaited_once_with(
+            "NCBIGene:1017", fields="_id", raw=True, include_extra=False
+        )
 
-    expected_response_body = {"success": True}
-    assert isinstance(response.json, dict)
-    assert response.http_version == "HTTP/1.1"
-    assert response.content_type == "application/json"
-    assert response.is_success
-    assert not response.is_error
-    assert response.is_closed
-    assert response.status_code == 200
-    assert response.encoding == "utf-8"
-    assert response.json == expected_response_body
+        assert request.method == "GET"
+        assert request.query_string == ""
+        assert request.scheme == "http"
+        assert request.server_path == endpoint
+
+        expected_response_body = {"success": True}
+        assert isinstance(response.json, dict)
+        assert response.http_version == "HTTP/1.1"
+        assert response.content_type == "application/json"
+        assert response.is_success
+        assert not response.is_error
+        assert response.is_closed
+        assert response.status_code == 200
+        assert response.encoding == "utf-8"
+        assert response.json == expected_response_body
 
 
 @pytest.mark.unit
@@ -44,21 +51,28 @@ async def test_status_head(test_annotator: sanic.Sanic, endpoint: str):
     """
     Tests the Status endpoint HEAD when the response is HTTP 200
     """
-    request, response = await test_annotator.asgi_client.request(method="head", url=endpoint)
+    with patch.object(
+        Annotator, "annotate_curie", return_value={"NCBIGene:1017": [{"query": "1017", "_id": "1017"}]}
+    ) as mock_annotate_curie:
+        request, response = await test_annotator.asgi_client.request(method="head", url=endpoint)
 
-    assert request.method == "HEAD"
-    assert request.query_string == ""
-    assert request.scheme == "http"
-    assert request.server_path == endpoint
+        mock_annotate_curie.assert_awaited_once_with(
+            "NCBIGene:1017", fields="_id", raw=True, include_extra=False
+        )
 
-    assert response.json is None
-    assert response.http_version == "HTTP/1.1"
-    assert response.content_type == "application/json"
-    assert response.is_success
-    assert not response.is_error
-    assert response.is_closed
-    assert response.status_code == 200
-    assert response.encoding == "utf-8"
+        assert request.method == "HEAD"
+        assert request.query_string == ""
+        assert request.scheme == "http"
+        assert request.server_path == endpoint
+
+        assert response.json is None
+        assert response.http_version == "HTTP/1.1"
+        assert response.content_type == "application/json"
+        assert response.is_success
+        assert not response.is_error
+        assert response.is_closed
+        assert response.status_code == 200
+        assert response.encoding == "utf-8"
 
 
 @pytest.mark.unit

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -453,6 +453,7 @@ async def test_query_annotations_keeps_biothings_default(monkeypatch):
     assert result == {"1017": [{"query": "1017", "_id": "1017"}]}
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_append_extra_annotations_skips_missing_query_client(monkeypatch):
     annotator = Annotator()
@@ -461,6 +462,45 @@ async def test_append_extra_annotations_skips_missing_query_client(monkeypatch):
     monkeypatch.setattr(
         "biothings_annotator.annotator.annotator.get_query_client",
         lambda node_type, query_backend, api_host, elasticsearch_connection: None,
+    )
+
+    await annotator.append_extra_annotations(node_d)
+
+    assert node_d == {"CHEMBL.COMPOUND:CHEMBL123": [{"query": "CHEMBL123", "_id": "CHEMBL123"}]}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_append_extra_annotations_skips_empty_subset(monkeypatch):
+    annotator = Annotator()
+    node_d = {"NCBIGene:1017": [{"query": "1017", "_id": "1017"}]}
+
+    def fail_get_query_client(node_type, query_backend, api_host, elasticsearch_connection):
+        raise AssertionError("empty extra subset should not request a query client")
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        fail_get_query_client,
+    )
+
+    await annotator.append_extra_annotations(node_d, node_id_subset=[])
+
+    assert node_d == {"NCBIGene:1017": [{"query": "1017", "_id": "1017"}]}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_append_extra_annotations_skips_querymany_failure(monkeypatch):
+    annotator = Annotator()
+    node_d = {"CHEMBL.COMPOUND:CHEMBL123": [{"query": "CHEMBL123", "_id": "CHEMBL123"}]}
+
+    class FailingExtraClient:
+        async def querymany(self, query_list, scopes, fields):
+            raise RuntimeError("extra annotations unavailable")
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        lambda node_type, query_backend, api_host, elasticsearch_connection: FailingExtraClient(),
     )
 
     await annotator.append_extra_annotations(node_d)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,6 +2,7 @@
 Exercises the query methods within the biothings_annotator package
 """
 
+import json
 import logging
 import random
 from typing import Dict, List
@@ -17,7 +18,7 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("node_type", ["gene", "chem", "disease", "phenotype", "NULL"])
+@pytest.mark.parametrize("node_type", ["gene", "chem", "disease", "NULL"])
 def test_annotation_client(node_type: str):
     """
     Tests accessing different flavors of the biothings client from within the scope of the annotator
@@ -35,6 +36,77 @@ def test_annotation_client(node_type: str):
     else:
         with pytest.raises(ValueError):
             utils.get_client(node_type, SERVICE_PROVIDER_API_HOST)
+
+
+@pytest.mark.unit
+def test_endpoint_annotation_client_uses_configured_url(monkeypatch):
+    """
+    Endpoint-backed clients should be built from SERVICE_PROVIDER_API_HOST without
+    requiring the live metadata endpoint in this unit test.
+    """
+    client_parameters = ANNOTATOR_CLIENTS["phenotype"]["client"]
+    original_instance = client_parameters.get("instance")
+    original_cache_key = client_parameters.get("instance_cache_key")
+    had_cache_key = "instance_cache_key" in client_parameters
+    fake_client = object()
+    calls = []
+
+    def fake_get_async_client(**kwargs):
+        calls.append(kwargs)
+        return fake_client
+
+    try:
+        client_parameters["instance"] = None
+        client_parameters.pop("instance_cache_key", None)
+        monkeypatch.setattr(biothings_client, "get_async_client", fake_get_async_client)
+
+        client = utils.get_client("phenotype", SERVICE_PROVIDER_API_HOST)
+    finally:
+        client_parameters["instance"] = original_instance
+        if had_cache_key:
+            client_parameters["instance_cache_key"] = original_cache_key
+        else:
+            client_parameters.pop("instance_cache_key", None)
+
+    assert client is fake_client
+    assert calls == [
+        {
+            "biothing_type": None,
+            "instance": True,
+            "url": f"{SERVICE_PROVIDER_API_HOST}/hpo",
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_endpoint_annotation_client_returns_none_on_metadata_failure(monkeypatch):
+    """
+    BioThings endpoint client construction reads remote metadata. If that remote
+    service is down or returns non-JSON, the caller should get None instead of a
+    leaked metadata parsing exception.
+    """
+    client_parameters = ANNOTATOR_CLIENTS["phenotype"]["client"]
+    original_instance = client_parameters.get("instance")
+    original_cache_key = client_parameters.get("instance_cache_key")
+    had_cache_key = "instance_cache_key" in client_parameters
+
+    def fail_get_async_client(**kwargs):
+        raise json.JSONDecodeError("Expecting value", "", 0)
+
+    try:
+        client_parameters["instance"] = None
+        client_parameters.pop("instance_cache_key", None)
+        monkeypatch.setattr(biothings_client, "get_async_client", fail_get_async_client)
+
+        client = utils.get_client("phenotype", SERVICE_PROVIDER_API_HOST)
+    finally:
+        client_parameters["instance"] = original_instance
+        if had_cache_key:
+            client_parameters["instance_cache_key"] = original_cache_key
+        else:
+            client_parameters.pop("instance_cache_key", None)
+
+    assert client is None
 
 
 @pytest.mark.unit

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -46,3 +46,54 @@ async def test_annotation_transform(curie_prefix: str):
     assert response_transformer.data_cache == {}  # explicit empty dict
 
     response_transformer.transform()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_chem_transform_does_not_load_atc_cache(monkeypatch):
+    annotation_instance = Annotator()
+    query_response = {"1017": [{"query": "1017", "_id": "1017", "symbol": "CDK2"}]}
+
+    def fail_get_query_client(node_type, query_backend, api_host, elasticsearch_connection):
+        raise AssertionError("non-chem transforms should not load extra ATC metadata")
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        fail_get_query_client,
+    )
+
+    response = await annotation_instance.transform(query_response, node_type="gene")
+
+    assert response == query_response
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_chem_transform_continues_when_atc_cache_load_fails(monkeypatch):
+    annotation_instance = Annotator()
+    query_response = {
+        "CHEMBL123": [
+            {
+                "query": "CHEMBL123",
+                "_id": "CHEMBL123",
+                "chembl": {
+                    "drug_indications": [{"mesh_id": "D012345"}],
+                    "atc_classifications": "A01AB02",
+                },
+            }
+        ]
+    }
+
+    def fail_get_query_client(node_type, query_backend, api_host, elasticsearch_connection):
+        raise RuntimeError("extra metadata unavailable")
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        fail_get_query_client,
+    )
+
+    response = await annotation_instance.transform(query_response, node_type="chem")
+    chembl_hit = response["CHEMBL123"][0]
+
+    assert chembl_hit["chembl"]["drug_indications"] == [{"mesh_id": "MESH:D012345"}]
+    assert "atc_classifications" not in chembl_hit

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -10,6 +10,7 @@ import random
 import pytest
 
 from biothings_annotator import ANNOTATOR_CLIENTS, BIOLINK_PREFIX_to_BioThings, Annotator, ResponseTransformer, utils
+from biothings_annotator.annotator import transformer
 from biothings_annotator.annotator.settings import SERVICE_PROVIDER_API_HOST
 
 logger = logging.getLogger(__name__)
@@ -97,3 +98,27 @@ async def test_chem_transform_continues_when_atc_cache_load_fails(monkeypatch):
 
     assert chembl_hit["chembl"]["drug_indications"] == [{"mesh_id": "MESH:D012345"}]
     assert "atc_classifications" not in chembl_hit
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_atc_cache_load_failure_does_not_cache_partial_results():
+    cache_key = "test-atc-cache-load-failure"
+    transformer.atc_cache.pop(cache_key, None)
+
+    class FailingAtcClient:
+        async def query(self, query, fields, fetch_all):
+            async def results():
+                yield {"atc": {"code": "A01", "name": "Stomatological preparations"}}
+                raise RuntimeError("ATC stream failed")
+
+            return results()
+
+    with pytest.raises(RuntimeError):
+        await transformer.load_atc_cache(
+            SERVICE_PROVIDER_API_HOST,
+            atc_client=FailingAtcClient(),
+            cache_key=cache_key,
+        )
+
+    assert cache_key not in transformer.atc_cache


### PR DESCRIPTION
Summary:
- make /status use a raw minimal annotation so health probes do not depend on transformation or extra enrichment
- load ATC metadata only for chem transforms and skip ATC/extra enrichment when the optional extra service is unavailable
- remove the live HPO metadata dependency from unit client-construction coverage and add outage regressions

Tests:
- .venv/bin/python -m pytest -m unit tests/ (51 passed, 73 deselected)