### PR TITLE
Expose query backend in version endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The annotator query backend is controlled with `ANNOTATOR_QUERY_BACKEND`. Suppor
 `biothings` and `elasticsearch`; when unset, the service uses `biothings`.
 The Helm/Jenkins deployment defaults set `ANNOTATOR_QUERY_BACKEND=elasticsearch`; set it to
 `biothings` during deployment to switch back.
+The `/version` endpoint reports the active `query_backend` and, when Elasticsearch is active,
+the selected `elasticsearch_connection`.
 
 
 ### Builds

--- a/biothings_annotator/application/views/metadata.py
+++ b/biothings_annotator/application/views/metadata.py
@@ -62,4 +62,4 @@ class VersionView(HTTPMethodView):
         except Exception as exc:
             logger.error(f"Error getting GitHub commit hash: {exc}")
             result = self.build_response_body("Unknown")
-            return sanic.json(result)
+            return sanic.json(result, headers=self.default_headers)

--- a/biothings_annotator/application/views/metadata.py
+++ b/biothings_annotator/application/views/metadata.py
@@ -9,6 +9,8 @@ from sanic import json
 from sanic.views import HTTPMethodView
 from sanic.request import Request
 
+from biothings_annotator.annotator import Annotator
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +26,16 @@ class VersionView(HTTPMethodView):
             version = version_file.read().strip()
             return version
 
+    def build_response_body(self, version: str):
+        annotator = Annotator()
+        result = {
+            "version": version,
+            "query_backend": annotator.query_backend,
+        }
+        if annotator.query_backend == "elasticsearch":
+            result["elasticsearch_connection"] = annotator.elasticsearch_connection
+        return result
+
     async def get(self, _: Request) -> json:
         """
         API versioning endpoint
@@ -32,7 +44,7 @@ class VersionView(HTTPMethodView):
         repository as the version to check the commit HEAD.
         Allows for verifying what the latest commit is on the live instance
 
-        Will return {"version": "Unknown"} is unable to generate a hash
+        Will return {"version": "Unknown", "query_backend": "..."} if unable to read the version file.
         """
         try:
             version = "Unknown"
@@ -44,10 +56,10 @@ class VersionView(HTTPMethodView):
             except Exception as exc:
                 logger.error(f"Error getting GitHub commit hash from version.txt file: {exc}")
 
-            result = {"version": version}
+            result = self.build_response_body(version)
             return sanic.json(result, headers=self.default_headers)
 
         except Exception as exc:
             logger.error(f"Error getting GitHub commit hash: {exc}")
-            result = {"version": "Unknown"}
+            result = self.build_response_body("Unknown")
             return sanic.json(result)

--- a/biothings_annotator/webapp/openapi.json
+++ b/biothings_annotator/webapp/openapi.json
@@ -77,7 +77,7 @@
                     },
                     "query_backend": {
                       "type": "string",
-                      "enum": ["biothings", "elasticsearch"]
+                      "description": "Configured runtime query backend."
                     },
                     "elasticsearch_connection": {
                       "type": "string",

--- a/biothings_annotator/webapp/openapi.json
+++ b/biothings_annotator/webapp/openapi.json
@@ -74,6 +74,14 @@
                   "properties": {
                     "version": {
                       "type": "string"
+                    },
+                    "query_backend": {
+                      "type": "string",
+                      "enum": ["biothings", "elasticsearch"]
+                    },
+                    "elasticsearch_connection": {
+                      "type": "string",
+                      "description": "Selected Elasticsearch connection label, present when query_backend is elasticsearch."
                     }
                   }
                 }

--- a/tests/test_application_endpoints.py
+++ b/tests/test_application_endpoints.py
@@ -8,6 +8,7 @@ import sanic
 
 from biothings_annotator import utils
 from biothings_annotator.annotator import Annotator
+from biothings_annotator.annotator.settings import QUERY_BACKEND_ENV
 from biothings_annotator.application.views import VersionView
 
 
@@ -135,10 +136,13 @@ async def test_status_get_failed_data_check(test_annotator: sanic.Sanic, endpoin
 @pytest.mark.unit
 @pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.parametrize("endpoint", ["/version/"])
-async def test_version_get_success(test_annotator: sanic.Sanic, endpoint: str):
+async def test_version_get_success(test_annotator: sanic.Sanic, endpoint: str, monkeypatch):
     """
     Test the Version endpoint GET method with a successful file read
     """
+    monkeypatch.delenv(QUERY_BACKEND_ENV, raising=False)
+    monkeypatch.delenv("ELASTICSEARCH_CONNECTION", raising=False)
+
     with patch.object(VersionView, "open_version_file", return_value="GITHUB_HASH_VERSION_ABC123") as mock_file_read:
         request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
 
@@ -150,7 +154,7 @@ async def test_version_get_success(test_annotator: sanic.Sanic, endpoint: str):
         assert request.scheme == "http"
         assert request.server_path == endpoint
 
-        expected_response_body = {"version": "GITHUB_HASH_VERSION_ABC123"}
+        expected_response_body = {"version": "GITHUB_HASH_VERSION_ABC123", "query_backend": "biothings"}
         assert response.http_version == "HTTP/1.1"
         assert response.content_type == "application/json"
         assert response.is_success
@@ -164,10 +168,49 @@ async def test_version_get_success(test_annotator: sanic.Sanic, endpoint: str):
 @pytest.mark.unit
 @pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.parametrize("endpoint", ["/version/"])
-async def test_version_get_file_not_found(test_annotator: sanic.Sanic, endpoint: str):
+async def test_version_get_reports_elasticsearch_backend(test_annotator: sanic.Sanic, endpoint: str, monkeypatch):
+    """
+    Test the Version endpoint GET method includes runtime backend metadata.
+    """
+    monkeypatch.setenv(QUERY_BACKEND_ENV, "elasticsearch")
+    monkeypatch.setenv("ELASTICSEARCH_CONNECTION", "ci_forward")
+
+    with patch.object(VersionView, "open_version_file", return_value="GITHUB_HASH_VERSION_ABC123") as mock_file_read:
+        request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
+
+        mock_file_read.assert_called_once()
+
+        assert request.method == "GET"
+        assert response.status_code == 200
+        assert request.query_string == ""
+        assert request.scheme == "http"
+        assert request.server_path == endpoint
+
+        expected_response_body = {
+            "version": "GITHUB_HASH_VERSION_ABC123",
+            "query_backend": "elasticsearch",
+            "elasticsearch_connection": "ci_forward",
+        }
+        assert response.http_version == "HTTP/1.1"
+        assert response.content_type == "application/json"
+        assert response.is_success
+        assert not response.is_error
+        assert response.is_closed
+        assert response.status_code == 200
+        assert response.encoding == "utf-8"
+        assert response.json == expected_response_body
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio(loop_scope="module")
+@pytest.mark.parametrize("endpoint", ["/version/"])
+async def test_version_get_file_not_found(test_annotator: sanic.Sanic, endpoint: str, monkeypatch):
     """
     Test the Version endpoint GET method when version.txt is not found
     """
+    monkeypatch.delenv(QUERY_BACKEND_ENV, raising=False)
+    monkeypatch.delenv("ELASTICSEARCH_CONNECTION", raising=False)
+
     with patch.object(VersionView, "open_version_file", side_effect=FileNotFoundError) as mock_file_read:
         request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
 
@@ -179,7 +222,7 @@ async def test_version_get_file_not_found(test_annotator: sanic.Sanic, endpoint:
         assert request.scheme == "http"
         assert request.server_path == endpoint
 
-        expected_response_body = {"version": "Unknown"}
+        expected_response_body = {"version": "Unknown", "query_backend": "biothings"}
         assert response.http_version == "HTTP/1.1"
         assert response.content_type == "application/json"
         assert response.is_success
@@ -193,10 +236,13 @@ async def test_version_get_file_not_found(test_annotator: sanic.Sanic, endpoint:
 @pytest.mark.unit
 @pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.parametrize("endpoint", ["/version/"])
-async def test_version_get_exception(test_annotator: sanic.Sanic, endpoint: str):
+async def test_version_get_exception(test_annotator: sanic.Sanic, endpoint: str, monkeypatch):
     """
     Test the Version endpoint GET method when an exception occurs
     """
+    monkeypatch.delenv(QUERY_BACKEND_ENV, raising=False)
+    monkeypatch.delenv("ELASTICSEARCH_CONNECTION", raising=False)
+
     with patch.object(VersionView, "open_version_file", side_effect=Exception("Simulated error")) as mock_file_read:
         request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
 
@@ -208,7 +254,7 @@ async def test_version_get_exception(test_annotator: sanic.Sanic, endpoint: str)
         assert request.scheme == "http"
         assert request.server_path == endpoint
 
-        expected_response_body = {"version": "Unknown"}
+        expected_response_body = {"version": "Unknown", "query_backend": "biothings"}
         assert response.http_version == "HTTP/1.1"
         assert response.content_type == "application/json"
         assert response.is_success

--- a/tests/test_application_endpoints.py
+++ b/tests/test_application_endpoints.py
@@ -267,6 +267,37 @@ async def test_version_get_exception(test_annotator: sanic.Sanic, endpoint: str,
 
 @pytest.mark.unit
 @pytest.mark.asyncio(loop_scope="module")
+@pytest.mark.parametrize("endpoint", ["/version/"])
+async def test_version_get_outer_exception_keeps_cache_header(
+    test_annotator: sanic.Sanic, endpoint: str, monkeypatch
+):
+    """
+    Test the Version endpoint preserves default headers on the outer fallback path.
+    """
+    monkeypatch.delenv(QUERY_BACKEND_ENV, raising=False)
+    monkeypatch.delenv("ELASTICSEARCH_CONNECTION", raising=False)
+
+    with patch.object(
+        VersionView,
+        "build_response_body",
+        side_effect=[
+            Exception("Simulated response error"),
+            {"version": "Unknown", "query_backend": "biothings"},
+        ],
+    ) as mock_build_response_body:
+        request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
+
+        assert mock_build_response_body.call_count == 2
+
+        assert request.method == "GET"
+        assert response.status_code == 200
+        expected_cache_control = f"max-age={test_annotator.config.CACHE_MAX_AGE}, public"
+        assert response.headers["Cache-Control"] == expected_cache_control
+        assert response.json == {"version": "Unknown", "query_backend": "biothings"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio(loop_scope="module")
 @pytest.mark.parametrize("data_store", ["expected_curie.json"])
 async def test_curie_get(temporary_data_storage: Union[str, Path], test_annotator: sanic.Sanic, data_store: Dict):
     """


### PR DESCRIPTION
## Summary
- add runtime `query_backend` metadata to `/version`
- include `elasticsearch_connection` when the active backend is Elasticsearch
- document the deployment-monitoring signal and cover default/ES version responses in tests

## Tests
- `git diff --check`
- `.venv/bin/python -m pytest -m unit tests/test_application_endpoints.py::test_version_get_success tests/test_application_endpoints.py::test_version_get_reports_elasticsearch_backend tests/test_application_endpoints.py::test_version_get_file_not_found tests/test_application_endpoints.py::test_version_get_exception`

## Notes
- `python -m json.tool biothings_annotator/webapp/openapi.json` still fails because `origin/main` already has unescaped multiline description strings outside this change.