### PR TITLE
Use CI Elasticsearch connection in deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ The Helm/Jenkins deployment defaults set `ANNOTATOR_QUERY_BACKEND=elasticsearch`
 to switch back.
 Set `ELASTICSEARCH_CONNECTION` to one of the named presets in
 `biothings_annotator/annotator/settings.py`. The `ci` preset points at
-`http://core-components-es.ci.transltr.io:9200`.
+`http://core-components-es.ci.transltr.io:9200`. The `ci_local_forward` preset is for local
+port-forward use; `ci_forward` remains as a deprecated alias.
 The `/version` endpoint reports the active `query_backend` and, when Elasticsearch is active,
 the selected `elasticsearch_connection`.
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,12 @@ python3 -m biothings_annotator --host "172.84.29.248" --port 9384 --workers 12 -
 
 The annotator query backend is controlled with `ANNOTATOR_QUERY_BACKEND`. Supported values are
 `biothings` and `elasticsearch`; when unset, the service uses `biothings`.
-The Helm/Jenkins deployment defaults set `ANNOTATOR_QUERY_BACKEND=elasticsearch`; set it to
-`biothings` during deployment to switch back.
+The Helm/Jenkins deployment defaults set `ANNOTATOR_QUERY_BACKEND=elasticsearch` and
+`ELASTICSEARCH_CONNECTION=ci`; set `ANNOTATOR_QUERY_BACKEND` to `biothings` during deployment
+to switch back.
+Set `ELASTICSEARCH_CONNECTION` to one of the named presets in
+`biothings_annotator/annotator/settings.py`. The `ci` preset points at
+`http://core-components-es.ci.transltr.io:9200`.
 The `/version` endpoint reports the active `query_backend` and, when Elasticsearch is active,
 the selected `elasticsearch_connection`.
 

--- a/biothings_annotator/annotator/settings.py
+++ b/biothings_annotator/annotator/settings.py
@@ -21,6 +21,11 @@ ELASTICSEARCH_CONNECTIONS = {
         "host": "http://localhost:9200",
         "headers": {"Host": "core-components-es.ci.transltr.io"},
     },
+    # Deprecated alias for compatibility with existing local-forward overrides.
+    "ci_forward": {
+        "host": "http://localhost:9200",
+        "headers": {"Host": "core-components-es.ci.transltr.io"},
+    },
 }
 ELASTICSEARCH_REQUEST_TIMEOUT = 30
 ELASTICSEARCH_QUERY_SIZE = 10

--- a/biothings_annotator/annotator/settings.py
+++ b/biothings_annotator/annotator/settings.py
@@ -8,6 +8,10 @@ QUERY_BACKEND = "biothings"
 QUERY_BACKEND_ENV = "ANNOTATOR_QUERY_BACKEND"
 
 ELASTICSEARCH_CONNECTION = "ci"
+CI_LOCAL_FORWARD_ELASTICSEARCH_CONNECTION = {
+    "host": "http://localhost:9200",
+    "headers": {"Host": "core-components-es.ci.transltr.io"},
+}
 ELASTICSEARCH_CONNECTIONS = {
     "local": {
         "host": "http://localhost:9200",
@@ -17,15 +21,9 @@ ELASTICSEARCH_CONNECTIONS = {
         "host": "http://core-components-es.ci.transltr.io:9200",
         "headers": {},
     },
-    "ci_local_forward": {
-        "host": "http://localhost:9200",
-        "headers": {"Host": "core-components-es.ci.transltr.io"},
-    },
+    "ci_local_forward": CI_LOCAL_FORWARD_ELASTICSEARCH_CONNECTION,
     # Deprecated alias for compatibility with existing local-forward overrides.
-    "ci_forward": {
-        "host": "http://localhost:9200",
-        "headers": {"Host": "core-components-es.ci.transltr.io"},
-    },
+    "ci_forward": CI_LOCAL_FORWARD_ELASTICSEARCH_CONNECTION,
 }
 ELASTICSEARCH_REQUEST_TIMEOUT = 30
 ELASTICSEARCH_QUERY_SIZE = 10

--- a/biothings_annotator/annotator/settings.py
+++ b/biothings_annotator/annotator/settings.py
@@ -7,7 +7,7 @@ SERVICE_PROVIDER_API_HOST = "https://biothings.ci.transltr.io"
 QUERY_BACKEND = "biothings"
 QUERY_BACKEND_ENV = "ANNOTATOR_QUERY_BACKEND"
 
-ELASTICSEARCH_CONNECTION = "ci_forward"
+ELASTICSEARCH_CONNECTION = "ci"
 ELASTICSEARCH_CONNECTIONS = {
     "local": {
         "host": "http://localhost:9200",
@@ -17,7 +17,7 @@ ELASTICSEARCH_CONNECTIONS = {
         "host": "http://core-components-es.ci.transltr.io:9200",
         "headers": {},
     },
-    "ci_forward": {
+    "ci_local_forward": {
         "host": "http://localhost:9200",
         "headers": {"Host": "core-components-es.ci.transltr.io"},
     },

--- a/biothings_annotator/webapp/openapi.json
+++ b/biothings_annotator/webapp/openapi.json
@@ -81,7 +81,7 @@
                     },
                     "elasticsearch_connection": {
                       "type": "string",
-                      "description": "Selected Elasticsearch connection label, present when query_backend is elasticsearch."
+                      "description": "Selected Elasticsearch connection preset label, present when query_backend is elasticsearch."
                     }
                   }
                 }

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -23,7 +23,7 @@ containers:
   name: biothingsannotator
   es_host: ES_HOST_VALUE
   query_backend: elasticsearch
-  elasticsearch_connection: ci_forward
+  elasticsearch_connection: ci
   port: 9000
 
 env:

--- a/tests/test_application_endpoints.py
+++ b/tests/test_application_endpoints.py
@@ -173,7 +173,7 @@ async def test_version_get_reports_elasticsearch_backend(test_annotator: sanic.S
     Test the Version endpoint GET method includes runtime backend metadata.
     """
     monkeypatch.setenv(QUERY_BACKEND_ENV, "elasticsearch")
-    monkeypatch.setenv("ELASTICSEARCH_CONNECTION", "ci_forward")
+    monkeypatch.setenv("ELASTICSEARCH_CONNECTION", "ci")
 
     with patch.object(VersionView, "open_version_file", return_value="GITHUB_HASH_VERSION_ABC123") as mock_file_read:
         request, response = await test_annotator.asgi_client.request(method="get", url=endpoint)
@@ -189,7 +189,7 @@ async def test_version_get_reports_elasticsearch_backend(test_annotator: sanic.S
         expected_response_body = {
             "version": "GITHUB_HASH_VERSION_ABC123",
             "query_backend": "elasticsearch",
-            "elasticsearch_connection": "ci_forward",
+            "elasticsearch_connection": "ci",
         }
         assert response.http_version == "HTTP/1.1"
         assert response.content_type == "application/json"

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -178,7 +178,7 @@ def install_fake_query_clients(monkeypatch, registry):
 async def run_with_backend(backend, method_name, *args, **kwargs):
     annotator = Annotator()
     annotator.query_backend = backend
-    annotator.elasticsearch_connection = "ci_forward"
+    annotator.elasticsearch_connection = "ci"
     method = getattr(annotator, method_name)
     return await method(*args, **kwargs)
 

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -18,11 +18,11 @@ def test_annotator_can_switch_query_backend_by_assignment(monkeypatch):
 
     annotator = Annotator()
     assert annotator.query_backend == "biothings"
-    assert annotator.elasticsearch_connection == "ci_forward"
+    assert annotator.elasticsearch_connection == "ci"
 
     annotator.query_backend = "elasticsearch"
     assert annotator.query_backend == "elasticsearch"
-    assert annotator.elasticsearch_connection == "ci_forward"
+    assert annotator.elasticsearch_connection == "ci"
 
     annotator.elasticsearch_connection = "local"
     assert annotator.elasticsearch_connection == "local"
@@ -42,11 +42,11 @@ def test_annotator_uses_query_backend_environment(monkeypatch):
 
 
 def test_annotator_strips_elasticsearch_connection_environment(monkeypatch):
-    monkeypatch.setenv("ELASTICSEARCH_CONNECTION", " ci_forward ")
+    monkeypatch.setenv("ELASTICSEARCH_CONNECTION", " ci_local_forward ")
 
     annotator = Annotator()
 
-    assert annotator.elasticsearch_connection == "ci_forward"
+    assert annotator.elasticsearch_connection == "ci_local_forward"
 
 
 @pytest.mark.asyncio
@@ -121,8 +121,8 @@ async def test_elasticsearch_client_supports_configured_headers():
     assert result == [{"query": "1017", "notfound": True}]
 
 
-def test_elasticsearch_connection_config_supports_forwarded_ci_host():
-    assert get_elasticsearch_connection("ci_forward") == {
+def test_elasticsearch_connection_config_supports_local_forwarded_ci_host():
+    assert get_elasticsearch_connection("ci_local_forward") == {
         "host": "http://localhost:9200",
         "headers": {"Host": "core-components-es.ci.transltr.io"},
     }
@@ -134,13 +134,13 @@ def test_elasticsearch_client_uses_named_connection_config():
     try:
         elasticsearch_settings["instance"] = None
 
-        ci_forward_client = get_elasticsearch_client("gene", "ci_forward")
-        assert ci_forward_client.host == "http://localhost:9200"
-        assert ci_forward_client.headers == {"Host": "core-components-es.ci.transltr.io"}
-        assert get_elasticsearch_client("gene", "ci_forward") is ci_forward_client
+        ci_local_forward_client = get_elasticsearch_client("gene", "ci_local_forward")
+        assert ci_local_forward_client.host == "http://localhost:9200"
+        assert ci_local_forward_client.headers == {"Host": "core-components-es.ci.transltr.io"}
+        assert get_elasticsearch_client("gene", "ci_local_forward") is ci_local_forward_client
 
         local_client = get_elasticsearch_client("gene", "local")
-        assert local_client is not ci_forward_client
+        assert local_client is not ci_local_forward_client
         assert local_client.host == "http://localhost:9200"
         assert local_client.headers == {}
     finally:
@@ -394,7 +394,7 @@ async def test_elasticsearch_query_fetch_all_falls_back_when_point_in_time_is_un
 async def test_query_annotations_uses_configured_query_client(monkeypatch):
     annotator = Annotator()
     annotator.query_backend = "elasticsearch"
-    annotator.elasticsearch_connection = "ci_forward"
+    annotator.elasticsearch_connection = "ci"
     calls = []
 
     class FakeQueryClient:
@@ -423,7 +423,7 @@ async def test_query_annotations_uses_configured_query_client(monkeypatch):
             "node_type": "gene",
             "query_backend": "elasticsearch",
             "api_host": annotator.api_host,
-            "elasticsearch_connection": "ci_forward",
+            "elasticsearch_connection": "ci",
         },
         {
             "query_list": ["1017"],

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -15,6 +15,7 @@ from biothings_annotator.annotator.utils import get_elasticsearch_client, get_el
 
 def test_annotator_can_switch_query_backend_by_assignment(monkeypatch):
     monkeypatch.delenv(QUERY_BACKEND_ENV, raising=False)
+    monkeypatch.delenv("ELASTICSEARCH_CONNECTION", raising=False)
 
     annotator = Annotator()
     assert annotator.query_backend == "biothings"

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -9,7 +9,7 @@ import pytest
 
 from biothings_annotator.annotator.annotator import Annotator
 from biothings_annotator.annotator.elasticsearch import ElasticsearchAnnotatorClient
-from biothings_annotator.annotator.settings import ANNOTATOR_CLIENTS, QUERY_BACKEND_ENV
+from biothings_annotator.annotator.settings import ANNOTATOR_CLIENTS, ELASTICSEARCH_CONNECTIONS, QUERY_BACKEND_ENV
 from biothings_annotator.annotator.utils import get_elasticsearch_client, get_elasticsearch_connection
 
 
@@ -127,6 +127,7 @@ def test_elasticsearch_connection_config_supports_local_forwarded_ci_host():
         "host": "http://localhost:9200",
         "headers": {"Host": "core-components-es.ci.transltr.io"},
     }
+    assert ELASTICSEARCH_CONNECTIONS["ci_forward"] is ELASTICSEARCH_CONNECTIONS["ci_local_forward"]
     assert get_elasticsearch_connection("ci_local_forward") == expected_connection
     assert get_elasticsearch_connection("ci_forward") == expected_connection
 

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -122,10 +122,12 @@ async def test_elasticsearch_client_supports_configured_headers():
 
 
 def test_elasticsearch_connection_config_supports_local_forwarded_ci_host():
-    assert get_elasticsearch_connection("ci_local_forward") == {
+    expected_connection = {
         "host": "http://localhost:9200",
         "headers": {"Host": "core-components-es.ci.transltr.io"},
     }
+    assert get_elasticsearch_connection("ci_local_forward") == expected_connection
+    assert get_elasticsearch_connection("ci_forward") == expected_connection
 
 
 def test_elasticsearch_client_uses_named_connection_config():


### PR DESCRIPTION
## Summary
- set the deployment Elasticsearch connection preset to `ci` so CI uses `http://core-components-es.ci.transltr.io:9200` instead of localhost
- rename the localhost/Host-header preset from `ci_forward` to `ci_local_forward` to make its local-only behavior explicit
- update docs, OpenAPI text, and tests to report/use the `ci` deployment preset

## Context
The deployment log showed kube-probe hitting `/status` and getting HTTP 400 repeatedly until Kubernetes terminated the pod. The old deployment default `ci_forward` maps to `http://localhost:9200` with a Host header, which is not the actual CI ES location from inside the annotator pod.

## Tests
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_elasticsearch.py tests/test_backend_parity.py tests/test_application_endpoints.py::test_version_get_reports_elasticsearch_backend`