### PR TITLE
Rollback CI deploy backend to BioThings

### DIFF
--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     parameters {
         string(name: 'BUILD_VERSION', defaultValue: '', description: 'The build version to deploy (optional)')
         string(name: 'AWS_REGION', defaultValue: 'us-east-1', description: 'AWS Region to deploy')
-        choice(name: 'ANNOTATOR_QUERY_BACKEND', choices: ['elasticsearch', 'biothings'], description: 'Annotator query backend to deploy')
+        choice(name: 'ANNOTATOR_QUERY_BACKEND', choices: ['biothings', 'elasticsearch'], description: 'Annotator query backend to deploy')
     }
     triggers {
         pollSCM('H/5 * * * *')

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,5 +12,5 @@ sed -i.bak \
 rm values.yaml.bak
 
 helm -n ${namespace} upgrade --install ${projectName} \
-    --set containers.query_backend="${ANNOTATOR_QUERY_BACKEND:-elasticsearch}" \
+    --set containers.query_backend="${ANNOTATOR_QUERY_BACKEND:-biothings}" \
     -f values-ncats.yaml ./

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -22,7 +22,7 @@ image:
 containers:
   name: biothingsannotator
   es_host: ES_HOST_VALUE
-  query_backend: elasticsearch
+  query_backend: biothings
   elasticsearch_connection: ci
   port: 9000
 


### PR DESCRIPTION
## Summary
- make Jenkins default ANNOTATOR_QUERY_BACKEND back to biothings
- make Helm values default query_backend back to biothings
- make deploy.sh fallback use biothings while ES connectivity is investigated

## Validation
- git diff --check
- helm template not run locally: helm is not installed in this environment