### PR TITLE
Add OpenTelemetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ python3 -m biothings_annotator --host "172.84.29.248" --port 9384 --workers 12 -
 
 ##### Runtime configuration
 
+##### OpenTelemetry tracing
+
+The service can export Sanic request spans and downstream HTTPX spans to a
+Jaeger collector using OTLP over HTTP. Tracing is disabled by default and can
+be enabled without changing the configuration file:
+
+```shell
+export OPENTELEMETRY_ENABLED=true
+export OPENTELEMETRY_SERVICE_NAME=BioThingsAnnotator
+export OPENTELEMETRY_JAEGER_HOST=http://localhost
+export OPENTELEMETRY_JAEGER_PORT=4318
+python -m biothings_annotator
+```
+
+The exporter sends spans to
+`$OPENTELEMETRY_JAEGER_HOST:$OPENTELEMETRY_JAEGER_PORT/v1/traces`. Set
+`OPENTELEMETRY_EXCLUDED_URLS` to a comma-separated list of regular expressions
+to override the configured route exclusions. The Helm deployment enables
+tracing and targets `http://jaeger-otel-collector.sri:4318` by default.
+
 The annotator query backend is controlled with `ANNOTATOR_QUERY_BACKEND`. Supported values are
 `biothings` and `elasticsearch`; when unset, the service uses `biothings`.
 The Helm/Jenkins deployment defaults set `ANNOTATOR_QUERY_BACKEND=elasticsearch` and

--- a/biothings_annotator/application/__init__.py
+++ b/biothings_annotator/application/__init__.py
@@ -7,6 +7,7 @@ from sanic import Sanic
 from biothings_annotator.application.exceptions import build_exception_handers
 from biothings_annotator.application.middleware import build_middleware
 from biothings_annotator.application.static import build_static_routes, build_static_content
+from biothings_annotator.application.telemetry import configure_telemetry
 from biothings_annotator.application.views import build_routes
 
 logging.basicConfig()
@@ -62,6 +63,7 @@ def build_application(configuration: Dict = None) -> Sanic:
 
     application = Sanic(name="biothings-annotator")
     application.update_config(configuration_settings)
+    configure_telemetry(application, configuration["application"].get("telemetry", {}))
 
     application_routes = build_routes()
     static_routes = build_static_routes()

--- a/biothings_annotator/application/configuration/default.json
+++ b/biothings_annotator/application/configuration/default.json
@@ -10,6 +10,13 @@
         "sentry": {
             "SENTRY_CLIENT_KEY": ""
         },
+        "telemetry": {
+            "OPENTELEMETRY_ENABLED": false,
+            "OPENTELEMETRY_SERVICE_NAME": "BioThingsAnnotator",
+            "OPENTELEMETRY_JAEGER_HOST": "http://localhost",
+            "OPENTELEMETRY_JAEGER_PORT": 4318,
+            "OPENTELEMETRY_EXCLUDED_URLS": ["^/$", "^/status$", "^/version$", "^/webapp", "^/favicon\\.ico$"]
+        },
         "extension": {
             "cors": {
                 "CORS_ALLOW_HEADERS": "*",

--- a/biothings_annotator/application/telemetry.py
+++ b/biothings_annotator/application/telemetry.py
@@ -1,0 +1,128 @@
+"""OpenTelemetry tracing configuration for the Annotator web application."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sanic import Sanic
+
+logger = logging.getLogger(__name__)
+_initialized_pid = None
+
+DEFAULT_TELEMETRY_SETTINGS = {
+    "OPENTELEMETRY_ENABLED": False,
+    "OPENTELEMETRY_SERVICE_NAME": "BioThingsAnnotator",
+    "OPENTELEMETRY_JAEGER_HOST": "http://localhost",
+    "OPENTELEMETRY_JAEGER_PORT": 4318,
+    "OPENTELEMETRY_EXCLUDED_URLS": ["^/$", "^/status$", "^/version$", "^/webapp", "^/favicon\\.ico$"],
+}
+
+
+def _environment_value(name: str, default: Any) -> Any:
+    """Return an OpenTelemetry environment override, preserving useful types."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    if isinstance(default, bool):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(default, int):
+        return int(value)
+    if isinstance(default, Sequence) and not isinstance(default, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return value
+
+
+def telemetry_settings(configuration: Mapping[str, Any]) -> dict[str, Any]:
+    """Apply OPENTELEMETRY_* environment variables to file configuration."""
+    return {name: _environment_value(name, value) for name, value in configuration.items()}
+
+
+def _initialize_worker_telemetry(settings):
+    """Create the exporter lazily inside the worker handling the request."""
+    global _initialized_pid
+    current_pid = os.getpid()
+    if _initialized_pid == current_pid:
+        return
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    endpoint = settings["endpoint"]
+    provider = TracerProvider(resource=Resource.create({SERVICE_NAME: settings["service_name"]}))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
+    trace.set_tracer_provider(provider)
+    HTTPXClientInstrumentor().instrument()
+    _initialized_pid = current_pid
+    logger.warning("OpenTelemetry worker is exporting traces to %s", endpoint)
+
+
+async def _start_request_span(request):
+    settings = request.app.ctx.opentelemetry_settings
+    if any(re.search(pattern, request.path) for pattern in settings["excluded_urls"]):
+        return
+    _initialize_worker_telemetry(settings)
+    from opentelemetry import propagate, trace
+
+    span_context = trace.get_tracer(__name__).start_as_current_span(
+        f"{request.method} {request.path}",
+        context=propagate.extract(dict(request.headers)),
+        kind=trace.SpanKind.SERVER,
+        attributes={
+            "http.request.method": request.method,
+            "url.path": request.path,
+            "url.scheme": request.scheme,
+            "server.address": request.host.split(":", 1)[0],
+        },
+    )
+    request.ctx.opentelemetry_span_context = span_context
+    span_context.__enter__()
+
+
+async def _finish_request_span(request, response):
+    span_context = getattr(request.ctx, "opentelemetry_span_context", None)
+    if span_context is None:
+        return
+    from opentelemetry import trace
+
+    span = trace.get_current_span()
+    span.set_attribute("http.response.status_code", response.status)
+    if response.status >= 500:
+        span.set_status(trace.Status(trace.StatusCode.ERROR))
+    span_context.__exit__(None, None, None)
+
+
+def configure_telemetry(application: Sanic, configuration: Mapping[str, Any]) -> bool:
+    """Instrument Sanic and HTTPX and export traces to Jaeger over OTLP/HTTP."""
+    configured_values = {**DEFAULT_TELEMETRY_SETTINGS, **configuration}
+    settings = telemetry_settings(configured_values)
+    if not settings.get("OPENTELEMETRY_ENABLED", False):
+        logger.info("OpenTelemetry is disabled")
+        return False
+
+    if importlib.util.find_spec("opentelemetry.sdk") is None:
+        logger.warning("OpenTelemetry is enabled but its SDK is not installed")
+        return False
+
+    host = str(settings.get("OPENTELEMETRY_JAEGER_HOST", "http://localhost")).rstrip("/")
+    port = int(settings.get("OPENTELEMETRY_JAEGER_PORT", 4318))
+    endpoint = f"{host}:{port}/v1/traces"
+    excluded_urls = settings.get("OPENTELEMETRY_EXCLUDED_URLS", [])
+    if not isinstance(excluded_urls, str):
+        excluded_urls = ",".join(excluded_urls)
+
+    application.ctx.opentelemetry_settings = {
+        "endpoint": endpoint,
+        "service_name": settings.get("OPENTELEMETRY_SERVICE_NAME", "BioThingsAnnotator"),
+        "excluded_urls": [pattern for pattern in excluded_urls.split(",") if pattern],
+    }
+    application.register_middleware(_start_request_span, "request")
+    application.register_middleware(_finish_request_span, "response")
+    return True

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -25,9 +25,9 @@ containers:
   query_backend: elasticsearch
   elasticsearch_connection: ci
   port: 9000
-
-env:
   OPENTELEMETRY_ENABLED_VALUE: True
+  OPENTELEMETRY_JAEGER_HOST_VALUE: http://jaeger-otel-collector.sri
+  OPENTELEMETRY_JAEGER_PORT_VALUE: 4318
 
 service:
   type: ClusterIP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,13 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-      args:
-        - ARG ANNOTATOR_REPO=https://github.com/biothings/biothings_annotator.git
-        - ARG ANNOTATOR_BRANCH=main
     container_name: biothings-annotator
+    environment:
+      OPENTELEMETRY_ENABLED: "true"
+      OPENTELEMETRY_SERVICE_NAME: BioThingsAnnotator
+      OPENTELEMETRY_JAEGER_HOST: http://host.docker.internal
+      OPENTELEMETRY_JAEGER_PORT: "4318"
+    extra_hosts:
+      - host.docker.internal:host-gateway
     ports:
       - 9000:9000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ classifiers = [
 dependencies = [
     "biothings_client >= 0.4.0",
     "httpx >= 0.28.0",
+    "opentelemetry-api >= 1.42.1",
+    "opentelemetry-sdk >= 1.42.1",
+    "opentelemetry-exporter-otlp-proto-http >= 1.42.1",
+    "opentelemetry-instrumentation >= 0.63b1",
+    "opentelemetry-instrumentation-httpx >= 0.63b1",
     "sanic[ext] == 24.12.0",
     "sentry-sdk[sanic] >= 2.19.0",
 ]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,27 @@
+"""Tests for OpenTelemetry configuration handling."""
+
+from biothings_annotator.application.telemetry import telemetry_settings
+
+
+def test_telemetry_settings_uses_file_defaults(monkeypatch):
+    monkeypatch.delenv("OPENTELEMETRY_ENABLED", raising=False)
+    configuration = {"OPENTELEMETRY_ENABLED": False, "OPENTELEMETRY_JAEGER_PORT": 4318}
+
+    assert telemetry_settings(configuration) == configuration
+
+
+def test_telemetry_settings_accepts_environment_overrides(monkeypatch):
+    monkeypatch.setenv("OPENTELEMETRY_ENABLED", "true")
+    monkeypatch.setenv("OPENTELEMETRY_JAEGER_PORT", "4319")
+    monkeypatch.setenv("OPENTELEMETRY_EXCLUDED_URLS", "^/$, ^/status$")
+    configuration = {
+        "OPENTELEMETRY_ENABLED": False,
+        "OPENTELEMETRY_JAEGER_PORT": 4318,
+        "OPENTELEMETRY_EXCLUDED_URLS": [],
+    }
+
+    assert telemetry_settings(configuration) == {
+        "OPENTELEMETRY_ENABLED": True,
+        "OPENTELEMETRY_JAEGER_PORT": 4319,
+        "OPENTELEMETRY_EXCLUDED_URLS": ["^/$", "^/status$"],
+    }


### PR DESCRIPTION
OpenTelemetry and Jaeger Integration
- Added OpenTelemetry tracing for HTTP requests.
- Exported traces to Jaeger.
- Added environment-based telemetry configuration.
- Added excluded-route support for health and static endpoints.
- Added Kubernetes/Helm Jaeger configuration.
- Added telemetry tests and documentation.