### PR TITLE
Update Python version matrix in workflow

### DIFF
--- a/.github/workflows/biothings_annotator_tests.yml
+++ b/.github/workflows/biothings_annotator_tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout biothings_annotator source
         uses: actions/checkout@v3


### PR DESCRIPTION
Removed Python 3.9 from the matrix of versions for testing.