### PR TITLE
Fix OTEL Jaeger endpoint in CI by baking config into the image.

### DIFF
--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -36,11 +36,7 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             - name: OPENTELEMETRY_ENABLED
-              value: "{{ .Values.containers.OPENTELEMETRY_ENABLED_VALUE }}"  
-            - name: OPENTELEMETRY_JAEGER_HOST
-              value: "{{ .Values.containers.OPENTELEMETRY_JAEGER_HOST_VALUE }}"
-            - name: OPENTELEMETRY_JAEGER_PORT
-              value: "{{ .Values.containers.OPENTELEMETRY_JAEGER_PORT_VALUE }}"      
+              value: "{{ .Values.containers.OPENTELEMETRY_ENABLED_VALUE }}"
           ports:
             - name: http
               containerPort: {{ .Values.containers.port }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -26,8 +26,6 @@ containers:
   elasticsearch_connection: ci
   port: 9000
   OPENTELEMETRY_ENABLED_VALUE: True
-  OPENTELEMETRY_JAEGER_HOST_VALUE: http://jaeger-otel-collector.sri
-  OPENTELEMETRY_JAEGER_PORT_VALUE: 4318
 
 service:
   type: ClusterIP

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,9 @@ WORKDIR /home/annotator/configuration
 COPY --from=builder --chown=annotator:annotator /build/annotator/biothings_annotator/application/configuration/default.json /home/annotator/configuration
 COPY --from=builder --chown=annotator:annotator /build/annotator/version.txt /home/annotator/configuration/version.txt
 
+# Override with corrected configuration
+COPY --from=builder --chown=annotator:annotator /build/annotator/docker/configuration/config.json /home/annotator/configuration/config.json
+
 COPY --from=builder --chown=annotator:annotator /build/annotator/docker/configuration/supervisord.conf /etc/supervisor/supervisord.conf
 COPY --from=builder --chown=annotator:annotator /build/annotator/docker/configuration/Caddyfile /etc/caddy/Caddyfile
 

--- a/docker/configuration/config.json
+++ b/docker/configuration/config.json
@@ -1,0 +1,46 @@
+{
+    "application": {
+        "configuration": {
+            "FALLBACK_ERROR_FORMAT": "json",
+            "REQUEST_TIMEOUT": 300,
+            "RESPONSE_TIMEOUT":	300,
+            "REQUEST_MAX_SIZE": 100000000,
+            "CACHE_MAX_AGE": 604800
+        },
+        "sentry": {
+            "SENTRY_CLIENT_KEY": ""
+        },
+        "telemetry": {
+            "OPENTELEMETRY_ENABLED": true,
+            "OPENTELEMETRY_SERVICE_NAME": "BioThingsAnnotator",
+            "OPENTELEMETRY_JAEGER_HOST": "http://jaeger-otel-collector.sri",
+            "OPENTELEMETRY_JAEGER_PORT": 4318,
+            "OPENTELEMETRY_EXCLUDED_URLS": ["^/$", "^/status$", "^/version$", "^/webapp", "^/favicon\\.ico$"]
+        },
+        "extension": {
+            "cors": {
+                "CORS_ALLOW_HEADERS": "*",
+                "CORS_METHODS": "*",
+                "CORS_ORIGINS": "*",
+                "CORS_SUPPORS_CREDENTIALS": false,
+                "CORS_MAX_AGE": 60
+            }
+        },
+        "runtime": {
+            "access_log": true,
+            "auto_reload": false,
+            "auto_tls": false,
+            "coffee": false,
+            "debug": false,
+            "fast": false,
+            "host": "0.0.0.0",
+            "motd": true,
+            "noisy_exceptions": true,
+            "port": 9000,
+            "single_process": false,
+            "unix": "",
+            "verbosity": 2,
+            "workers": 8
+        }
+    }
+}

--- a/docker/configuration/supervisord.conf
+++ b/docker/configuration/supervisord.conf
@@ -17,7 +17,7 @@ stderr_logfile_maxbytes=0
 stderr_logfile_backups=0
 
 [program:python_app]
-command=/home/annotator/venv/bin/python -m biothings_annotator --conf=/home/annotator/configuration/default.json --port 9001
+command=/home/annotator/venv/bin/python -m biothings_annotator --conf=/home/annotator/configuration/config.json --port 9001
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
The Helm chart was injecting OPENTELEMETRY_JAEGER_HOST/PORT from an
externally-managed CI values file that still pointed at the old Jaeger
agent address (jaeger-otel-agent.sri:6831), producing a schemeless URL
the OTLP HTTP exporter couldn't dispatch to.

Stop injecting those env vars from Helm and instead bake the correct
OTLP collector endpoint (http://jaeger-otel-collector.sri:4318) into
docker/configuration/config.json, mirroring how nameres and nodenorm
configure telemetry. The app now loads this file directly via --conf,
so the endpoint no longer depends on an external override.