### PR TITLE
Fix ES gene lookups crashing on non-numeric ids by scoping querymany per prefix.

### DIFF
--- a/biothings_annotator/annotator/annotator.py
+++ b/biothings_annotator/annotator/annotator.py
@@ -243,8 +243,8 @@ class Annotator:
         scopes. Prefix-specific groups prevent incompatible identifiers from being
         queried against fields such as the numeric Elasticsearch "retired" field.
         """
-        groups: "OrderedDict[Tuple, List[str]]" = OrderedDict()
-        scopes_by_key: Dict[Tuple, Union[str, List[str]]] = {}
+        groups: "OrderedDict[Union[str, Tuple[str, ...]], List[str]]" = OrderedDict()
+        scopes_by_key: Dict[Union[str, Tuple[str, ...]], Union[str, List[str]]] = {}
         for curie in node_list:
             prefix = curie.split(":", 1)[0]
             scopes = self._scopes_for_prefix(node_type, prefix)

--- a/biothings_annotator/annotator/annotator.py
+++ b/biothings_annotator/annotator/annotator.py
@@ -64,6 +64,22 @@ class Annotator:
             return f"{self.query_backend}:{self.elasticsearch_connection}"
         return f"{self.query_backend}:{self.api_host}"
 
+    def _default_scopes(self, node_type: str) -> Union[str, List[str]]:
+        """Return the backend-appropriate default query scopes for a node type."""
+        client_settings = ANNOTATOR_CLIENTS[node_type]
+        if self.query_backend == "elasticsearch":
+            return client_settings.get("elasticsearch_scopes", client_settings["scopes"])
+        return client_settings["scopes"]
+
+    def _scopes_for_prefix(self, node_type: str, prefix: str) -> Union[str, List[str]]:
+        """Return prefix-specific scopes using exact ES fields when configured."""
+        prefix_settings = BIOLINK_PREFIX_to_BioThings.get(prefix, {})
+        if self.query_backend == "elasticsearch":
+            elasticsearch_scopes = prefix_settings.get("elasticsearch_scopes")
+            if elasticsearch_scopes:
+                return elasticsearch_scopes
+        return prefix_settings.get("scopes") or self._default_scopes(node_type)
+
     async def query_biothings(
         self, node_type: str, query_list: List[str], fields: Optional[Union[str, List[str]]] = None
     ) -> Dict:
@@ -93,9 +109,9 @@ class Annotator:
         """
         Query annotations through the configured backend.
 
-        scopes defaults to the full ANNOTATOR_CLIENTS[node_type]["scopes"] list, but
-        callers that know the originating BIOLINK prefix should pass its narrower
-        per-prefix scopes (see BIOLINK_PREFIX_to_BioThings) instead.
+        scopes defaults to the backend-appropriate full scope list, but callers that
+        know the originating BIOLINK prefix should pass its narrower per-prefix scopes
+        (see BIOLINK_PREFIX_to_BioThings) instead.
         """
         client = get_query_client(
             node_type=node_type,
@@ -109,7 +125,7 @@ class Annotator:
 
         query_list = list(query_list)
         fields = fields or ANNOTATOR_CLIENTS[node_type].get("fields", "all")
-        scopes = scopes or ANNOTATOR_CLIENTS[node_type]["scopes"]
+        scopes = scopes or self._default_scopes(node_type)
         logger.info("Querying %s annotations for %s %ss...", self.query_backend, len(query_list), node_type)
         res = await client.querymany(query_list, scopes=scopes, fields=fields)
         logger.info("Done. %s %s annotation objects returned.", len(res), self.query_backend)
@@ -207,7 +223,7 @@ class Annotator:
             raise InvalidCurieError(curie)
 
         prefix = curie.split(":", 1)[0]
-        scopes = BIOLINK_PREFIX_to_BioThings.get(prefix, {}).get("scopes")
+        scopes = self._scopes_for_prefix(node_type, prefix)
         res = await self.query_annotations(node_type, [_id], fields=fields, scopes=scopes)
 
         if not raw:
@@ -219,22 +235,19 @@ class Annotator:
         curie_annotation = {curie: res.get(_id, {})}
         return curie_annotation
 
-    @staticmethod
     def _group_curies_by_scopes(
-        node_type: str, node_list: List[str]
+        self, node_type: str, node_list: List[str]
     ) -> List[Tuple[Union[str, List[str]], List[str]]]:
         """
-        Group curies of the same node_type by the querymany scopes that should be used
-        for them: curies whose BIOLINK prefix declares its own narrower "scopes" (see
-        BIOLINK_PREFIX_to_BioThings) are grouped by that; everything else falls back to
-        ANNOTATOR_CLIENTS[node_type]["scopes"] and stays in a single group, same as before.
+        Group curies of the same node_type by their backend-appropriate querymany
+        scopes. Prefix-specific groups prevent incompatible identifiers from being
+        queried against fields such as the numeric Elasticsearch "retired" field.
         """
-        default_scopes = ANNOTATOR_CLIENTS[node_type]["scopes"]
         groups: "OrderedDict[Tuple, List[str]]" = OrderedDict()
         scopes_by_key: Dict[Tuple, Union[str, List[str]]] = {}
         for curie in node_list:
             prefix = curie.split(":", 1)[0]
-            scopes = BIOLINK_PREFIX_to_BioThings.get(prefix, {}).get("scopes") or default_scopes
+            scopes = self._scopes_for_prefix(node_type, prefix)
             key = tuple(scopes) if isinstance(scopes, list) else scopes
             groups.setdefault(key, []).append(curie)
             scopes_by_key[key] = scopes

--- a/biothings_annotator/annotator/annotator.py
+++ b/biothings_annotator/annotator/annotator.py
@@ -3,7 +3,7 @@ Translator Node Annotator Service Handler
 """
 
 from collections import OrderedDict
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 import logging
 import os
 
@@ -12,6 +12,7 @@ import biothings_client
 from biothings_annotator.annotator.exceptions import InvalidCurieError, InvalidQueryBackendError, TRAPIInputError
 from biothings_annotator.annotator.settings import (
     ANNOTATOR_CLIENTS,
+    BIOLINK_PREFIX_to_BioThings,
     ELASTICSEARCH_CONNECTION,
     QUERY_BACKEND,
     QUERY_BACKEND_ALIASES,
@@ -83,10 +84,18 @@ class Annotator:
         return grouped_response
 
     async def query_annotations(
-        self, node_type: str, query_list: List[str], fields: Optional[Union[str, List[str]]] = None
+        self,
+        node_type: str,
+        query_list: List[str],
+        fields: Optional[Union[str, List[str]]] = None,
+        scopes: Optional[Union[str, List[str]]] = None,
     ) -> Dict:
         """
         Query annotations through the configured backend.
+
+        scopes defaults to the full ANNOTATOR_CLIENTS[node_type]["scopes"] list, but
+        callers that know the originating BIOLINK prefix should pass its narrower
+        per-prefix scopes (see BIOLINK_PREFIX_to_BioThings) instead.
         """
         client = get_query_client(
             node_type=node_type,
@@ -100,7 +109,7 @@ class Annotator:
 
         query_list = list(query_list)
         fields = fields or ANNOTATOR_CLIENTS[node_type].get("fields", "all")
-        scopes = ANNOTATOR_CLIENTS[node_type]["scopes"]
+        scopes = scopes or ANNOTATOR_CLIENTS[node_type]["scopes"]
         logger.info("Querying %s annotations for %s %ss...", self.query_backend, len(query_list), node_type)
         res = await client.querymany(query_list, scopes=scopes, fields=fields)
         logger.info("Done. %s %s annotation objects returned.", len(res), self.query_backend)
@@ -197,7 +206,9 @@ class Annotator:
         if not node_type:
             raise InvalidCurieError(curie)
 
-        res = await self.query_annotations(node_type, [_id], fields=fields)
+        prefix = curie.split(":", 1)[0]
+        scopes = BIOLINK_PREFIX_to_BioThings.get(prefix, {}).get("scopes")
+        res = await self.query_annotations(node_type, [_id], fields=fields, scopes=scopes)
 
         if not raw:
             res = await self.transform(res, node_type)
@@ -207,6 +218,27 @@ class Annotator:
 
         curie_annotation = {curie: res.get(_id, {})}
         return curie_annotation
+
+    @staticmethod
+    def _group_curies_by_scopes(
+        node_type: str, node_list: List[str]
+    ) -> List[Tuple[Union[str, List[str]], List[str]]]:
+        """
+        Group curies of the same node_type by the querymany scopes that should be used
+        for them: curies whose BIOLINK prefix declares its own narrower "scopes" (see
+        BIOLINK_PREFIX_to_BioThings) are grouped by that; everything else falls back to
+        ANNOTATOR_CLIENTS[node_type]["scopes"] and stays in a single group, same as before.
+        """
+        default_scopes = ANNOTATOR_CLIENTS[node_type]["scopes"]
+        groups: "OrderedDict[Tuple, List[str]]" = OrderedDict()
+        scopes_by_key: Dict[Tuple, Union[str, List[str]]] = {}
+        for curie in node_list:
+            prefix = curie.split(":", 1)[0]
+            scopes = BIOLINK_PREFIX_to_BioThings.get(prefix, {}).get("scopes") or default_scopes
+            key = tuple(scopes) if isinstance(scopes, list) else scopes
+            groups.setdefault(key, []).append(curie)
+            scopes_by_key[key] = scopes
+        return [(scopes_by_key[key], curies) for key, curies in groups.items()]
 
     async def _annotate_node_list_by_type(
         self, node_list_by_type: Dict, raw: bool = False, fields: Optional[Union[str, List[str]]] = None
@@ -224,22 +256,23 @@ class Annotator:
             # this is the list of original node ids like NCBIGene:1017, should be a unique list
             node_list = node_list_by_type[node_type]
 
-            # this is the list of query ids like 1017
-            query_list = [parse_curie(_id, return_type=False, return_id=True) for _id in node_list_by_type[node_type]]
+            for scopes, scoped_node_list in self._group_curies_by_scopes(node_type, node_list):
+                # this is the list of query ids like 1017
+                query_list = [parse_curie(_id, return_type=False, return_id=True) for _id in scoped_node_list]
 
-            # query_id to original id mapping
-            node_id_d = dict(zip(query_list, node_list))
-            res_by_id = await self.query_annotations(node_type, query_list, fields=fields)
-            if not raw:
-                res_by_id = await self.transform(res_by_id, node_type)
+                # query_id to original id mapping
+                node_id_d = dict(zip(query_list, scoped_node_list))
+                res_by_id = await self.query_annotations(node_type, query_list, fields=fields, scopes=scopes)
+                if not raw:
+                    res_by_id = await self.transform(res_by_id, node_type)
 
-            # map back to original node ids
-            # NOTE: we don't want to use `for node_id in res_by_id:` here, since we will mofiify res_by_id in the loop
-            for node_id in list(res_by_id.keys()):
-                orig_node_id = node_id_d[node_id]
-                if node_id != orig_node_id:
-                    res_by_id[orig_node_id] = res_by_id.pop(node_id)
-                yield (orig_node_id, res_by_id[orig_node_id])
+                # map back to original node ids
+                # NOTE: we don't want to use `for node_id in res_by_id:` here, since we will mofiify res_by_id in the loop
+                for node_id in list(res_by_id.keys()):
+                    orig_node_id = node_id_d[node_id]
+                    if node_id != orig_node_id:
+                        res_by_id[orig_node_id] = res_by_id.pop(node_id)
+                    yield (orig_node_id, res_by_id[orig_node_id])
 
     async def annotate_curie_list(
         self,

--- a/biothings_annotator/annotator/settings.py
+++ b/biothings_annotator/annotator/settings.py
@@ -33,15 +33,23 @@ ELASTICSEARCH_QUERY_BATCH_SIZE = 1000
 
 
 BIOLINK_PREFIX_to_BioThings = {
-    # "scopes" narrows the ES/BioThings querymany lookup to the fields that are
-    # actually relevant for this prefix, instead of the full "gene" scopes list.
-    # This matters because "retired" is a numeric field: including it for
-    # non-numeric ids (eg. UniProtKB accessions/isoforms) makes Elasticsearch
-    # fail the whole query while trying to coerce the term to a number.
+    # "scopes" contains BioThings query scopes. "elasticsearch_scopes" overrides
+    # those scopes with exact index field names when the two backends use different
+    # vocabularies. Keeping the mappings separate prevents numeric fields such as
+    # "retired" from being queried with non-numeric identifiers without losing hits
+    # stored in nested Elasticsearch leaf fields.
     "NCBIGene": {"type": "gene", "scopes": ["entrezgene", "retired"]},
     # "HGNC": {"type": "gene", "field": "HGNC"},
-    "ENSEMBL": {"type": "gene", "scopes": ["ensemblgene"]},
-    "UniProtKB": {"type": "gene", "scopes": ["uniprot", "accession"]},
+    "ENSEMBL": {
+        "type": "gene",
+        "scopes": ["ensemblgene"],
+        "elasticsearch_scopes": ["ensembl.gene"],
+    },
+    "UniProtKB": {
+        "type": "gene",
+        "scopes": ["uniprot", "accession"],
+        "elasticsearch_scopes": ["uniprot.Swiss-Prot", "uniprot.TrEMBL"],
+    },
     "INCHIKEY": {"type": "chem"},
     "CHEMBL.COMPOUND": {
         "type": "chem",
@@ -85,6 +93,13 @@ ANNOTATOR_CLIENTS = {
             "taxid",
         ],
         "scopes": ["entrezgene", "ensemblgene", "uniprot", "accession", "retired"],
+        "elasticsearch_scopes": [
+            "entrezgene",
+            "ensembl.gene",
+            "uniprot.Swiss-Prot",
+            "uniprot.TrEMBL",
+            "retired",
+        ],
     },
     "chem": {
         "client": {

--- a/biothings_annotator/annotator/settings.py
+++ b/biothings_annotator/annotator/settings.py
@@ -33,10 +33,15 @@ ELASTICSEARCH_QUERY_BATCH_SIZE = 1000
 
 
 BIOLINK_PREFIX_to_BioThings = {
-    "NCBIGene": {"type": "gene", "field": "entrezgene"},
+    # "scopes" narrows the ES/BioThings querymany lookup to the fields that are
+    # actually relevant for this prefix, instead of the full "gene" scopes list.
+    # This matters because "retired" is a numeric field: including it for
+    # non-numeric ids (eg. UniProtKB accessions/isoforms) makes Elasticsearch
+    # fail the whole query while trying to coerce the term to a number.
+    "NCBIGene": {"type": "gene", "scopes": ["entrezgene", "retired"]},
     # "HGNC": {"type": "gene", "field": "HGNC"},
-    "ENSEMBL": {"type": "gene", "field": "ensembl.gene"},
-    "UniProtKB": {"type": "gene", "field": "uniprot.Swiss-Prot"},
+    "ENSEMBL": {"type": "gene", "scopes": ["ensemblgene"]},
+    "UniProtKB": {"type": "gene", "scopes": ["uniprot", "accession"]},
     "INCHIKEY": {"type": "chem"},
     "CHEMBL.COMPOUND": {
         "type": "chem",

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -11,7 +11,7 @@ import pytest
 
 from biothings_annotator.annotator import transformer
 from biothings_annotator.annotator.annotator import Annotator
-from biothings_annotator.annotator.settings import ANNOTATOR_CLIENTS
+from biothings_annotator.annotator.settings import ANNOTATOR_CLIENTS, BIOLINK_PREFIX_to_BioThings
 
 
 ATC_ROWS = [
@@ -214,11 +214,15 @@ async def test_query_annotations_backend_parity_for_raw_grouped_hits(monkeypatch
         "9999": [{"query": "9999", "notfound": True}],
     }
 
-    for backend in ("biothings", "elasticsearch"):
+    expected_scopes_by_backend = {
+        "biothings": ANNOTATOR_CLIENTS["gene"]["scopes"],
+        "elasticsearch": ANNOTATOR_CLIENTS["gene"]["elasticsearch_scopes"],
+    }
+    for backend, expected_scopes in expected_scopes_by_backend.items():
         assert registry[backend]["gene"].querymany_calls == [
             {
                 "query_list": ["1017", "9999"],
-                "scopes": ANNOTATOR_CLIENTS["gene"]["scopes"],
+                "scopes": expected_scopes,
                 "fields": fields,
             }
         ]
@@ -388,7 +392,7 @@ async def test_annotate_curie_list_backend_parity_for_duplicate_and_unsupported_
         assert registry[backend]["gene"].querymany_calls == [
             {
                 "query_list": ["1017", "1017"],
-                "scopes": ANNOTATOR_CLIENTS["gene"]["scopes"],
+                "scopes": BIOLINK_PREFIX_to_BioThings["NCBIGene"]["scopes"],
                 "fields": ANNOTATOR_CLIENTS["gene"]["fields"],
             }
         ]

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -190,6 +190,46 @@ async def test_elasticsearch_querymany_formats_biothings_style_hits():
 
 
 @pytest.mark.asyncio
+async def test_elasticsearch_querymany_uses_mapped_uniprot_leaf_fields():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        lines = [json.loads(line) for line in request.content.decode().splitlines()]
+        assert lines[1]["query"]["bool"]["should"] == [
+            {"term": {"uniprot.Swiss-Prot": "Q86UK5"}},
+            {"term": {"uniprot.Swiss-Prot.keyword": "Q86UK5"}},
+            {"term": {"uniprot.TrEMBL": "Q86UK5"}},
+            {"term": {"uniprot.TrEMBL.keyword": "Q86UK5"}},
+        ]
+        return httpx.Response(
+            200,
+            json={
+                "responses": [
+                    {
+                        "hits": {
+                            "hits": [
+                                {
+                                    "_id": "132884",
+                                    "_source": {"symbol": "EVC2"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = ElasticsearchAnnotatorClient("http://localhost:9200", "gene", http_client=http_client)
+        result = await client.querymany(
+            ["Q86UK5"],
+            scopes=["uniprot.Swiss-Prot", "uniprot.TrEMBL"],
+            fields=["symbol"],
+        )
+
+    assert result == [{"symbol": "EVC2", "_id": "132884", "query": "Q86UK5"}]
+
+
+@pytest.mark.asyncio
 async def test_elasticsearch_client_supports_configured_headers():
     requests = []
 
@@ -535,21 +575,38 @@ async def test_query_annotations_uses_configured_query_client(monkeypatch):
         },
         {
             "query_list": ["1017"],
-            "scopes": ["entrezgene", "ensemblgene", "uniprot", "accession", "retired"],
+            "scopes": [
+                "entrezgene",
+                "ensembl.gene",
+                "uniprot.Swiss-Prot",
+                "uniprot.TrEMBL",
+                "retired",
+            ],
             "fields": ["symbol"],
         }
     ]
 
 
+@pytest.mark.parametrize(
+    "query_backend, expected_scopes",
+    [
+        ("biothings", ["uniprot", "accession"]),
+        ("elasticsearch", ["uniprot.Swiss-Prot", "uniprot.TrEMBL"]),
+    ],
+)
 @pytest.mark.asyncio
-async def test_annotate_curie_scopes_uniprotkb_isoform_to_uniprot_fields_only(monkeypatch):
+async def test_annotate_curie_uses_backend_specific_uniprot_scopes(
+    monkeypatch,
+    query_backend,
+    expected_scopes,
+):
     """
     A UniProtKB isoform id (eg. Q86UK5-2) must not be scoped against the numeric
     "retired" field, or Elasticsearch fails the whole query trying to coerce the
     non-numeric id to a number.
     """
     annotator = Annotator()
-    annotator.query_backend = "elasticsearch"
+    annotator.query_backend = query_backend
     calls = []
 
     class FakeQueryClient:
@@ -565,8 +622,41 @@ async def test_annotate_curie_scopes_uniprotkb_isoform_to_uniprot_fields_only(mo
     result = await annotator.annotate_curie("UniProtKB:Q86UK5-2", raw=True, include_extra=False)
 
     assert result == {"UniProtKB:Q86UK5-2": [{"query": "Q86UK5-2", "_id": "Q86UK5-2"}]}
-    assert calls == [{"query_list": ["Q86UK5-2"], "scopes": ["uniprot", "accession"]}]
+    assert calls == [{"query_list": ["Q86UK5-2"], "scopes": expected_scopes}]
     assert "retired" not in calls[0]["scopes"]
+
+
+@pytest.mark.parametrize(
+    "query_backend, expected_scopes",
+    [
+        ("biothings", ["ensemblgene"]),
+        ("elasticsearch", ["ensembl.gene"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_annotate_curie_uses_backend_specific_ensembl_scopes(
+    monkeypatch,
+    query_backend,
+    expected_scopes,
+):
+    annotator = Annotator()
+    annotator.query_backend = query_backend
+    calls = []
+
+    class FakeQueryClient:
+        async def querymany(self, query_list, scopes, fields):
+            calls.append({"query_list": query_list, "scopes": scopes})
+            return [{"query": "ENSG00000139618", "_id": "675"}]
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        lambda node_type, query_backend, api_host, elasticsearch_connection: FakeQueryClient(),
+    )
+
+    result = await annotator.annotate_curie("ENSEMBL:ENSG00000139618", raw=True, include_extra=False)
+
+    assert result == {"ENSEMBL:ENSG00000139618": [{"query": "ENSG00000139618", "_id": "675"}]}
+    assert calls == [{"query_list": ["ENSG00000139618"], "scopes": expected_scopes}]
 
 
 @pytest.mark.asyncio
@@ -590,12 +680,17 @@ async def test_annotate_curie_list_splits_gene_prefixes_into_separate_scoped_bat
         lambda node_type, query_backend, api_host, elasticsearch_connection: FakeQueryClient(),
     )
 
-    await annotator.annotate_curie_list(["NCBIGene:1017", "UniProtKB:Q86UK5-2"], raw=True, include_extra=False)
+    await annotator.annotate_curie_list(
+        ["NCBIGene:1017", "UniProtKB:Q86UK5-2", "ENSEMBL:ENSG00000139618"],
+        raw=True,
+        include_extra=False,
+    )
 
     calls_by_scopes = {tuple(call["scopes"]): call["query_list"] for call in calls}
     assert calls_by_scopes == {
         ("entrezgene", "retired"): ["1017"],
-        ("uniprot", "accession"): ["Q86UK5-2"],
+        ("uniprot.Swiss-Prot", "uniprot.TrEMBL"): ["Q86UK5-2"],
+        ("ensembl.gene",): ["ENSG00000139618"],
     }
 
 
@@ -604,9 +699,11 @@ async def test_query_annotations_keeps_biothings_default(monkeypatch):
     annotator = Annotator()
     annotator.query_backend = "biothings"
     annotator.api_host = "https://biothings.example.org"
+    calls = []
 
     class FakeQueryClient:
         async def querymany(self, query_list, scopes, fields):
+            calls.append({"query_list": query_list, "scopes": scopes, "fields": fields})
             return [{"query": "1017", "_id": "1017"}]
 
     monkeypatch.setattr(
@@ -617,6 +714,13 @@ async def test_query_annotations_keeps_biothings_default(monkeypatch):
     result = await annotator.query_annotations("gene", ["1017"])
 
     assert result == {"1017": [{"query": "1017", "_id": "1017"}]}
+    assert calls == [
+        {
+            "query_list": ["1017"],
+            "scopes": ["entrezgene", "ensemblgene", "uniprot", "accession", "retired"],
+            "fields": ANNOTATOR_CLIENTS["gene"]["fields"],
+        }
+    ]
 
 
 @pytest.mark.unit

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -542,6 +542,64 @@ async def test_query_annotations_uses_configured_query_client(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_annotate_curie_scopes_uniprotkb_isoform_to_uniprot_fields_only(monkeypatch):
+    """
+    A UniProtKB isoform id (eg. Q86UK5-2) must not be scoped against the numeric
+    "retired" field, or Elasticsearch fails the whole query trying to coerce the
+    non-numeric id to a number.
+    """
+    annotator = Annotator()
+    annotator.query_backend = "elasticsearch"
+    calls = []
+
+    class FakeQueryClient:
+        async def querymany(self, query_list, scopes, fields):
+            calls.append({"query_list": query_list, "scopes": scopes})
+            return [{"query": "Q86UK5-2", "_id": "Q86UK5-2"}]
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        lambda node_type, query_backend, api_host, elasticsearch_connection: FakeQueryClient(),
+    )
+
+    result = await annotator.annotate_curie("UniProtKB:Q86UK5-2", raw=True, include_extra=False)
+
+    assert result == {"UniProtKB:Q86UK5-2": [{"query": "Q86UK5-2", "_id": "Q86UK5-2"}]}
+    assert calls == [{"query_list": ["Q86UK5-2"], "scopes": ["uniprot", "accession"]}]
+    assert "retired" not in calls[0]["scopes"]
+
+
+@pytest.mark.asyncio
+async def test_annotate_curie_list_splits_gene_prefixes_into_separate_scoped_batches(monkeypatch):
+    """
+    Mixed gene CURIE prefixes in one batch must not be merged into a single
+    querymany call using the full "gene" scopes list, since that would apply
+    the numeric "retired" scope to non-numeric ids from other prefixes.
+    """
+    annotator = Annotator()
+    annotator.query_backend = "elasticsearch"
+    calls = []
+
+    class FakeQueryClient:
+        async def querymany(self, query_list, scopes, fields):
+            calls.append({"query_list": list(query_list), "scopes": scopes})
+            return [{"query": query_id, "_id": query_id} for query_id in query_list]
+
+    monkeypatch.setattr(
+        "biothings_annotator.annotator.annotator.get_query_client",
+        lambda node_type, query_backend, api_host, elasticsearch_connection: FakeQueryClient(),
+    )
+
+    await annotator.annotate_curie_list(["NCBIGene:1017", "UniProtKB:Q86UK5-2"], raw=True, include_extra=False)
+
+    calls_by_scopes = {tuple(call["scopes"]): call["query_list"] for call in calls}
+    assert calls_by_scopes == {
+        ("entrezgene", "retired"): ["1017"],
+        ("uniprot", "accession"): ["Q86UK5-2"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_query_annotations_keeps_biothings_default(monkeypatch):
     annotator = Annotator()
     annotator.query_backend = "biothings"


### PR DESCRIPTION
## Summary
- Gene lookups batched every CURIE prefix (NCBIGene, ENSEMBL, UniProtKB) into
  one Elasticsearch `bool.should` query scoped against all five gene fields,
  including `retired`, which is numeric. Elasticsearch fails the entire
  request when it can't coerce a non-numeric id (UniProtKB accessions,
  isoforms like `Q86UK5-2`, Ensembl gene ids) against that field.
- Added a per-prefix `scopes` override in `BIOLINK_PREFIX_to_BioThings`
  (`NCBIGene` -> `entrezgene`/`retired`, `ENSEMBL` -> `ensemblgene`,
  `UniProtKB` -> `uniprot`/`accession`) and split `querymany` batches by
  resolved scopes in `Annotator._annotate_node_list_by_type` /
  `annotate_curie`, so each prefix only queries its relevant fields.
- This also removes the previously unused `field` key on those entries,
  which was dead code that looked like it was meant to do this scoping but
  was never read anywhere.
- Non-gene node types (chem/disease/phenotype) are unaffected — they still
  batch into a single request per node type, same as before.
