### PR TITLE
Exclude Downstream OpenTelemetry Traces for Unmatched/Excluded Inbound Requests

### DIFF
--- a/biothings_annotator/application/telemetry.py
+++ b/biothings_annotator/application/telemetry.py
@@ -23,6 +23,15 @@ DEFAULT_TELEMETRY_SETTINGS = {
 }
 
 
+def _suppress_request_instrumentation(request):
+    """Prevent excluded requests from producing orphaned child spans."""
+    from opentelemetry.instrumentation.utils import suppress_instrumentation
+
+    suppression = suppress_instrumentation()
+    suppression.__enter__()
+    request.ctx.opentelemetry_suppression = suppression
+
+
 def _environment_value(name: str, default: Any) -> Any:
     """Return an OpenTelemetry environment override, preserving useful types."""
     value = os.getenv(name)
@@ -70,8 +79,10 @@ async def _start_request_span(request):
     # has no route, so do not create telemetry for requests that will become a
     # 404 (or otherwise never reach an application handler).
     if getattr(request, "route", None) is None:
+        _suppress_request_instrumentation(request)
         return
     if any(re.search(pattern, request.path) for pattern in settings["excluded_urls"]):
+        _suppress_request_instrumentation(request)
         return
     _initialize_worker_telemetry(settings)
     from opentelemetry import propagate, trace
@@ -92,6 +103,11 @@ async def _start_request_span(request):
 
 
 async def _finish_request_span(request, response):
+    suppression = getattr(request.ctx, "opentelemetry_suppression", None)
+    if suppression is not None:
+        suppression.__exit__(None, None, None)
+        return
+
     span_context = getattr(request.ctx, "opentelemetry_span_context", None)
     if span_context is None:
         return

--- a/biothings_annotator/application/telemetry.py
+++ b/biothings_annotator/application/telemetry.py
@@ -66,6 +66,11 @@ def _initialize_worker_telemetry(settings):
 
 async def _start_request_span(request):
     settings = request.app.ctx.opentelemetry_settings
+    # Sanic resolves the route before request middleware runs. An unmatched URL
+    # has no route, so do not create telemetry for requests that will become a
+    # 404 (or otherwise never reach an application handler).
+    if getattr(request, "route", None) is None:
+        return
     if any(re.search(pattern, request.path) for pattern in settings["excluded_urls"]):
         return
     _initialize_worker_telemetry(settings)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,5 +1,10 @@
-"""Tests for OpenTelemetry configuration handling."""
+"""Tests for OpenTelemetry configuration and request filtering."""
 
+from types import SimpleNamespace
+
+import pytest
+
+from biothings_annotator.application import telemetry
 from biothings_annotator.application.telemetry import telemetry_settings
 
 
@@ -25,3 +30,29 @@ def test_telemetry_settings_accepts_environment_overrides(monkeypatch):
         "OPENTELEMETRY_JAEGER_PORT": 4319,
         "OPENTELEMETRY_EXCLUDED_URLS": ["^/$", "^/status$"],
     }
+
+
+def _request(path, route):
+    settings = {"excluded_urls": ["^/status$"]}
+    return SimpleNamespace(
+        app=SimpleNamespace(ctx=SimpleNamespace(opentelemetry_settings=settings)),
+        ctx=SimpleNamespace(),
+        route=route,
+        path=path,
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_request_span_ignores_unmatched_routes(monkeypatch):
+    initialize = lambda settings: pytest.fail("telemetry should not be initialized")
+    monkeypatch.setattr(telemetry, "_initialize_worker_telemetry", initialize)
+
+    await telemetry._start_request_span(_request("/does-not-exist", None))
+
+
+@pytest.mark.asyncio
+async def test_start_request_span_applies_exclusions_after_route_match(monkeypatch):
+    initialize = lambda settings: pytest.fail("telemetry should not be initialized")
+    monkeypatch.setattr(telemetry, "_initialize_worker_telemetry", initialize)
+
+    await telemetry._start_request_span(_request("/status", object()))

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 import pytest
+from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 
 from biothings_annotator.application import telemetry
 from biothings_annotator.application.telemetry import telemetry_settings
@@ -47,7 +48,12 @@ async def test_start_request_span_ignores_unmatched_routes(monkeypatch):
     initialize = lambda settings: pytest.fail("telemetry should not be initialized")
     monkeypatch.setattr(telemetry, "_initialize_worker_telemetry", initialize)
 
-    await telemetry._start_request_span(_request("/does-not-exist", None))
+    request = _request("/does-not-exist", None)
+    await telemetry._start_request_span(request)
+
+    assert not is_instrumentation_enabled()
+    await telemetry._finish_request_span(request, SimpleNamespace(status=404))
+    assert is_instrumentation_enabled()
 
 
 @pytest.mark.asyncio
@@ -55,4 +61,9 @@ async def test_start_request_span_applies_exclusions_after_route_match(monkeypat
     initialize = lambda settings: pytest.fail("telemetry should not be initialized")
     monkeypatch.setattr(telemetry, "_initialize_worker_telemetry", initialize)
 
-    await telemetry._start_request_span(_request("/status", object()))
+    request = _request("/status", object())
+    await telemetry._start_request_span(request)
+
+    assert not is_instrumentation_enabled()
+    await telemetry._finish_request_span(request, SimpleNamespace(status=200))
+    assert is_instrumentation_enabled()


### PR DESCRIPTION
# Summary
This PR ensures that when an inbound request is excluded or unmatched, all subsequent downstream OpenTelemetry (OTel) instrumentation during that request's lifecycle is completely suppressed.

# Problem
Previously, if an inbound endpoint was excluded from tracing (for example, health check routes like /status), the initial parent span for the endpoint was correctly ignored. However, any downstream external calls made during that request's lifecycle (e.g., a query to Elasticsearch) would still generate and export spans to Jaeger. This led to fragmented, orphaned downstream spans in Jaeger and unnecessary noise for excluded routes.
- Before this PR: /status (Excluded) $\rightarrow$ makes ES call $\rightarrow$ Jaeger captures ES span (orphaned trace).
- After this PR: /status (Excluded) $\rightarrow$ makes ES call $\rightarrow$ No spans captured at all for the entire request lifecycle.

# Solution
Implemented suppression of the tracing context for the duration of the request lifecycle when an inbound request is matched against the exclusion list or is unmatched by the application router. This ensures that downstream client instrumentations (HTTP, DB, Elasticsearch, etc.) respect the parent's excluded status and do not initiate new spans.